### PR TITLE
Fix unix timestamp and data types

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ See [here](applications/tasks) for further information of each `appTask` current
 
 ## Application remote control
 
-Each `appTask` has a `/<IMEI>/<appTaskName>Control` topic where commands can be sent down to that `appTask`. Start, Stop task, measure 'now' etc.
+Each `appTask` has a `<IMEI>/<appTaskName>Control` topic where commands can be sent down to that `appTask`. Start, Stop task, measure 'now' etc.
 
 A typical log output shows what the commands are:
-> Subscribed to callback topic: /351457830026040/SensorControl
+> Subscribed to callback topic: 351457830026040/SensorControl
 >
 > With these commands:
 >
@@ -47,7 +47,7 @@ A typical log output shows what the commands are:
 
 ## Application published data
 
-Each appTask can publish their data/information to the MQTT broker to their own specific topic. This topic is well defined, being `/<IMEI>/<appTaskName>`.
+Each appTask can publish their data/information to the MQTT broker to their own specific topic. This topic is well defined, being `<IMEI>/<appTaskName>`.
 
 This data/information should normally be formatted as JSON.
 

--- a/applications/cellular_tracker/README.md
+++ b/applications/cellular_tracker/README.md
@@ -29,7 +29,7 @@ For the MQTT connection, there is a #define of the MQTT credentials which to use
 The application can be remotely controlled through various topics which are subscribed to by the application tasks. 
 
 A typical log output shows what the commands are for each task, and main application
-> Subscribed to callback topic: /351457830026040/SensorControl
+> Subscribed to callback topic: 351457830026040/SensorControl
 >
 > With these commands:
 >

--- a/applications/tasks/README.md
+++ b/applications/tasks/README.md
@@ -56,30 +56,30 @@ The API for this TASK only requires a MQTT or MQTT-SN flag to be set in the mqtt
 # Sending commands
 Application tasks subscribe to a particular MQTT topic so they can listen to commands coming from the cloud. Each MQTT command topic starts with the \<IMEI> of the module and then "xxxControl" for that xxxTask.
 
-## Topic : /\<IMEI>/AppControl
+## Topic : <IMEI>/AppControl
  - SET_DWELL_TIME \<dwell time ms> : Sets the time between the main application requests for signal quality measurement+location
 
-## Topic : /\<IMEI>/SignalQualityControl
+## Topic : <IMEI>/SignalQualityControl
  - MEASURE_NOW : Request a signal quality measurement to be made now and published to the cloud via MQTT
  - START_TASK \[dwell time seconds] : Starts the task loop with the specified dwell time, or uses the default if missing
  - STOP_TASK : Stops the task loop
 
-## Topic : /\<IMEI>/SensorsControl
+## Topic : <IMEI>/SensorsControl
  - MEASURE_NOW : Request a sensor measurement to be made now and published to the cloud via MQTT
  - START_TASK \[dwell time seconds] : Starts the task loop with the specified dwell time, or uses the default if missing
  - STOP_TASK : Stops the task loop
 
-## Topic : /\<IMEI>/LocationControl
+## Topic : <IMEI>/LocationControl
  - LOCATION_NOW : Request a location measurement to be made now and published to the cloud via MQTT
  - START_TASK \[dwell time seconds] : Starts the task loop with the specified dwell time, or uses the default if missing
  - STOP_TASK : Stops the task loop
 
-## Topic : /\<IMEI>/ExampleControl
+## Topic : <IMEI>/ExampleControl
  - RUN_EXAMPLE : Runs the example task's "event" (printLog)
  - START_TASK \[dwell time seconds] : Starts the task loop with the specified dwell time, or uses the default if missing
  - STOP_TASK : Stops the task loop
 
-## Topic : /\<IMEI>/SensorsControl
+## Topic : <IMEI>/SensorsControl
  - MEASURE_NOW : Request a sensor measurement to be made now and published to the cloud via MQTT
  - START_TASK \[dwell time seconds] : Starts the task loop with the specified dwell time, or uses the default if missing
  - STOP_TASK : Stops the task loop

--- a/applications/tasks/locationTask.c
+++ b/applications/tasks/locationTask.c
@@ -133,14 +133,14 @@ static void publishLocation(uLocation_t location)
     getTimeStamp(timestamp);
 
     char format[] = "{"                                         \
-            "\"Timestamp\":%" PRId64 ", "                       \
+            "\"Timestamp\":%" PRId64 ","                        \
             "\"Location\":{"                                    \
-                "\"Altitude\":%d, "                             \
-                "\"Latitude\":%c%d.%07d, "                      \
-                "\"Longitude\":%c%d.%07d, "                     \
-                "\"Accuracy\":%d, "                             \
-                "\"Speed\":%d, "                                \
-                "\"GNSSTimestamp\":%" PRId64 "}"                     \
+                "\"Altitude\":%d,"                              \
+                "\"Latitude\":%c%d.%07d,"                       \
+                "\"Longitude\":%c%d.%07d,"                      \
+                "\"Accuracy\":%d,"                              \
+                "\"Speed\":%d,"                                 \
+                "\"GNSSTimestamp\":%" PRId64 "}"                \
         "}";
 
     //struct tm *t = gmtime(&location.timeUtc);

--- a/applications/tasks/locationTask.c
+++ b/applications/tasks/locationTask.c
@@ -133,7 +133,7 @@ static void publishLocation(uLocation_t location)
     getTimeStamp(timestamp);
 
     char format[] = "{"                                         \
-            "\"Timestamp\":\"%s\", "                            \
+            "\"Timestamp\":%" PRId64 ", "                       \
             "\"Location\":{"                                    \
                 "\"Altitude\":\"%d\", "                  \
                 "\"Latitude\":\"%c%d.%07d\", "                  \
@@ -145,7 +145,7 @@ static void publishLocation(uLocation_t location)
 
     struct tm *t = gmtime(&location.timeUtc);
 
-    snprintf(jsonBuffer, JSON_STRING_LENGTH, format, timestamp,
+    snprintf(jsonBuffer, JSON_STRING_LENGTH, format, (unixNetworkTime + (uPortGetTickTimeMs() / 1000)),
             location.altitudeMillimetres,
             FRACTION_FORMAT(location.latitudeX1e7,  TEN_MILLIONTH),
             FRACTION_FORMAT(location.longitudeX1e7, TEN_MILLIONTH),

--- a/applications/tasks/locationTask.c
+++ b/applications/tasks/locationTask.c
@@ -140,10 +140,10 @@ static void publishLocation(uLocation_t location)
                 "\"Longitude\":%c%d.%07d, "                     \
                 "\"Accuracy\":%d, "                             \
                 "\"Speed\":%d, "                                \
-                "\"Time\":\"%4d-%02d-%02d %02d:%02d:%02d\"}"    \
+                "\"GNSSTimestamp\":%" PRId64 "}"                     \
         "}";
 
-    struct tm *t = gmtime(&location.timeUtc);
+    //struct tm *t = gmtime(&location.timeUtc);
 
     snprintf(jsonBuffer, JSON_STRING_LENGTH, format, (unixNetworkTime + (uPortGetTickTimeMs() / 1000)),
             location.altitudeMillimetres,
@@ -151,7 +151,7 @@ static void publishLocation(uLocation_t location)
             FRACTION_FORMAT(location.longitudeX1e7, TEN_MILLIONTH),
             location.radiusMillimetres,
             location.speedMillimetresPerSecond,
-            t->tm_year + 1900, t->tm_mon, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
+            location.timeUtc);
 
     sendMQTTMessage(topicName, jsonBuffer, U_MQTT_QOS_AT_MOST_ONCE, false);
     writeAlways(jsonBuffer);

--- a/applications/tasks/locationTask.c
+++ b/applications/tasks/locationTask.c
@@ -104,7 +104,7 @@ static char fractionConvert(int32_t x1e7,
                           int32_t *pFraction,
                           int32_t divider)
 {
-    char prefix = '+';
+    char prefix = ' ';
 
     // Deal with the sign
     if (x1e7 < 0) {
@@ -135,11 +135,11 @@ static void publishLocation(uLocation_t location)
     char format[] = "{"                                         \
             "\"Timestamp\":%" PRId64 ", "                       \
             "\"Location\":{"                                    \
-                "\"Altitude\":\"%d\", "                  \
-                "\"Latitude\":\"%c%d.%07d\", "                  \
-                "\"Longitude\":\"%c%d.%07d\", "                 \
-                "\"Accuracy\":\"%d\", "                  \
-                "\"Speed\":\"%d\", "                     \
+                "\"Altitude\":%d, "                             \
+                "\"Latitude\":%c%d.%07d, "                      \
+                "\"Longitude\":%c%d.%07d, "                     \
+                "\"Accuracy\":%d, "                             \
+                "\"Speed\":%d, "                                \
                 "\"Time\":\"%4d-%02d-%02d %02d:%02d:%02d\"}"    \
         "}";
 

--- a/applications/tasks/mqttTask.c
+++ b/applications/tasks/mqttTask.c
@@ -691,7 +691,7 @@ int32_t subscribeToTopicAsync(const char *taskTopicName, uMqttQos_t qos, callbac
         goto cleanUp;
     }
 
-    snprintf(tempTopicName, TEMP_TOPIC_NAME_SIZE, "/%s/%s", gSerialNumber, taskTopicName);
+    snprintf(tempTopicName, TEMP_TOPIC_NAME_SIZE, "%s/%s", gSerialNumber, taskTopicName);
     topicName = uStrDup(tempTopicName);
     if (topicName == NULL) {
         writeError("Failed to create task topic name - not enough memory");

--- a/applications/tasks/signalQualityTask.c
+++ b/applications/tasks/signalQualityTask.c
@@ -107,7 +107,7 @@ static void measureSignalQuality(void)
         int32_t earfcn = uCellInfoGetEarfcn(gDeviceHandle);
 
         char format[] = "{" \
-            "\"Timestamp\":\"%s\", "        \
+            "\"Timestamp\":%" PRId64 ", "   \
             "\"CellQuality\":{"             \
                 "\"RSRP\":\"%d\", "         \
                 "\"RSRQ\":\"%d\", "         \
@@ -126,7 +126,7 @@ static void measureSignalQuality(void)
         // See macro "IS_NETWORK_AVAILABLE"
         gIsNetworkSignalValid = (rsrp != 0) && (rsrq != 2147483647);
 
-        snprintf(jsonBuffer, JSON_STRING_LENGTH, format, timestamp, 
+        snprintf(jsonBuffer, JSON_STRING_LENGTH, format, (unixNetworkTime + (uPortGetTickTimeMs() / 1000)), 
                                 rsrp, rsrq, rssi, snr, rxqual, 
                                 cellId, earfcn, operatorMcc, operatorMnc, pOperatorName);
         sendMQTTMessage(topicName, jsonBuffer, U_MQTT_QOS_AT_MOST_ONCE, false);

--- a/applications/tasks/signalQualityTask.c
+++ b/applications/tasks/signalQualityTask.c
@@ -109,12 +109,12 @@ static void measureSignalQuality(void)
         char format[] = "{" \
             "\"Timestamp\":%" PRId64 ", "   \
             "\"CellQuality\":{"             \
-                "\"RSRP\":\"%d\", "         \
-                "\"RSRQ\":\"%d\", "         \
-                "\"RSSI\":\"%d\", "         \
-                "\"SNR\":\"%d\"}, "         \
+                "\"RSRP\":%d, "             \
+                "\"RSRQ\":%d, "             \
+                "\"RSSI\":%d, "             \
+                "\"SNR\":%d}, "             \
             "\"CellInfo\":{"                \
-                "\"RxQual\":\"%d\", "       \
+                "\"RxQual\":%d, "           \
                 "\"CellID\":\"%d\", "       \
                 "\"EARFCN\":\"%d\", "       \
                 "\"PLMN\":\"%03d%02d\", "   \

--- a/applications/tasks/signalQualityTask.c
+++ b/applications/tasks/signalQualityTask.c
@@ -107,17 +107,17 @@ static void measureSignalQuality(void)
         int32_t earfcn = uCellInfoGetEarfcn(gDeviceHandle);
 
         char format[] = "{" \
-            "\"Timestamp\":%" PRId64 ", "   \
+            "\"Timestamp\":%" PRId64 ","    \
             "\"CellQuality\":{"             \
-                "\"RSRP\":%d, "             \
-                "\"RSRQ\":%d, "             \
-                "\"RSSI\":%d, "             \
-                "\"SNR\":%d}, "             \
+                "\"RSRP\":%d,"              \
+                "\"RSRQ\":%d,"              \
+                "\"RSSI\":%d,"              \
+                "\"SNR\":%d},"              \
             "\"CellInfo\":{"                \
-                "\"RxQual\":%d, "           \
-                "\"CellID\":\"%d\", "       \
-                "\"EARFCN\":\"%d\", "       \
-                "\"PLMN\":\"%03d%02d\", "   \
+                "\"RxQual\":%d,"            \
+                "\"CellID\":\"%d\","        \
+                "\"EARFCN\":\"%d\","        \
+                "\"PLMN\":\"%03d%02d\","    \
                 "\"Operator\":\"%s\"}"      \
         "}";
 

--- a/applications/tasks/taskControl.h
+++ b/applications/tasks/taskControl.h
@@ -42,7 +42,7 @@
 
 #define TASK_INITIALISED        ((taskConfig != NULL) && taskConfig->initialised)
 
-#define CREATE_TOPIC_NAME       snprintf(topicName, MAX_TOPIC_NAME_SIZE, "/%s/%s", (const char *)gSerialNumber, TASK_NAME)
+#define CREATE_TOPIC_NAME       snprintf(topicName, MAX_TOPIC_NAME_SIZE, "%s/%s", (const char *)gSerialNumber, TASK_NAME)
 
 #define EXIT_IF_CANT_RUN_TASK   if (taskConfig == NULL || !TASK_INITIALISED) {                          \
                                     writeWarn("%s task is not initialised yet, not starting.",          \


### PR DESCRIPTION
This PR hopefully will fix #8, #9 and #15.

The leading forward slash is removed from mqtt topic.

The updated mqtt payload format will be:
```json
{
  "Timestamp": 1692338624,
  "CellQuality": {
    "RSRP": -81,
    "RSRQ": -7,
    "RSSI": -53,
    "SNR": 18
  },
  "CellInfo": {
    "RxQual": 5,
    "CellID": "166",
    "EARFCN": "9410",
    "PLMN": "50501",
    "Operator": "Telstra Mobile"
  }
}
```

```json
{
  "Timestamp": 1692338654,
  "Location": {
    "Altitude": 118795,
    "Latitude": -37.7999,
    "Longitude": 145.1999,
    "Accuracy": 4249,
    "Speed": 32,
    "GNSSTimestamp": 1692338655
  }
}
```

Cheers,
Paul